### PR TITLE
fix: fix android: foreground bug

### DIFF
--- a/app/src/main/res/layout-land/cover_fragment.xml
+++ b/app/src/main/res/layout-land/cover_fragment.xml
@@ -22,7 +22,7 @@
             android:layout_marginTop="32dp"
             android:layout_marginEnd="32dp"
             android:layout_marginBottom="32dp"
-            android:foreground="?rectSelector"
+            android:background="?rectSelector"
             android:importantForAccessibility="no"
             android:scaleType="fitCenter"
             squareImageView:direction="height"

--- a/app/src/main/res/layout-land/fullcard_cover_fragment.xml
+++ b/app/src/main/res/layout-land/fullcard_cover_fragment.xml
@@ -29,7 +29,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
-                android:foreground="?rectSelector"
+                android:background="?rectSelector"
                 android:importantForAccessibility="no"
                 android:scaleType="centerCrop"
                 squareImageView:direction="height"

--- a/app/src/main/res/layout/blur_card_cover_fragment.xml
+++ b/app/src/main/res/layout/blur_card_cover_fragment.xml
@@ -142,7 +142,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:foreground="?rectSelector"
+            android:background="?rectSelector"
             android:importantForAccessibility="no"
             android:scaleType="centerCrop"
             squareImageView:direction="height"

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -18,7 +18,7 @@
         android:layout_gravity="center"
         android:layout_marginHorizontal="16dp"
         android:layout_weight="0"
-        android:foreground="?rectSelector"
+        android:background="?rectSelector"
         android:importantForAccessibility="no"
         android:scaleType="fitCenter"
         squareImageView:direction="height"

--- a/app/src/main/res/layout/drive_cover_fragment.xml
+++ b/app/src/main/res/layout/drive_cover_fragment.xml
@@ -23,7 +23,7 @@
         android:layout_gravity="center"
         android:layout_marginHorizontal="16dp"
         android:layout_weight="0"
-        android:foreground="?rectSelector"
+        android:background="?rectSelector"
         android:importantForAccessibility="no"
         android:scaleType="fitCenter"
         squareImageView:direction="height"

--- a/app/src/main/res/layout/full_cover_fragment.xml
+++ b/app/src/main/res/layout/full_cover_fragment.xml
@@ -131,7 +131,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:foreground="?rectSelector"
+        android:background="?rectSelector"
         android:importantForAccessibility="no"
         android:scaleType="centerCrop"
         squareImageView:direction="height"

--- a/app/src/main/res/layout/fullcard_cover_fragment.xml
+++ b/app/src/main/res/layout/fullcard_cover_fragment.xml
@@ -28,7 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:foreground="?rectSelector"
+            android:background="?rectSelector"
             android:importantForAccessibility="no"
             android:scaleType="centerCrop"
             squareImageView:direction="height"

--- a/app/src/main/res/layout/vinyl_cover_fragment.xml
+++ b/app/src/main/res/layout/vinyl_cover_fragment.xml
@@ -19,7 +19,7 @@
         android:layout_marginHorizontal="16dp"
         android:layout_weight="0"
         android:visibility="gone"
-        android:foreground="?attr/selectableItemBackgroundBorderless"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:importantForAccessibility="no"
         android:scaleType="fitCenter"
         squareImageView:direction="height"


### PR DESCRIPTION
We discovered a CC (Configuration Compatibility) Bug in your library. This issue is caused by the abnormal display of `android:foreground` in Android API levels below 23. As shown in the image below (To make the presentation more evident, we specifically chose an example during the image loading process), when the software runs on API level 22, clicking the image does not trigger any response, whereas when running on API level 23, the click effect appears as expected. The example shown below is just one sample; the other `img_cover` instances exhibit the same effect.
![image](https://github.com/user-attachments/assets/e8693adf-bbb6-4e48-82ef-a74d387b0dcc)

Our repair tool recommends replacing `android:foreground` with `android:background` to ensure compatibility with lower API levels. Furthermore, we have tested this fix on multiple higher API levels, and it has proven to be effective. Below is the result after applying the fix. Looking forward to your reply.
![image](https://github.com/user-attachments/assets/00ff6db3-e3f6-4272-9a5c-01996874445f)
