### PR TITLE
Use MIXED_CONTENT_COMPATIBILITY_MODE in PodWebView

### DIFF
--- a/app/src/main/java/allen/town/podcast/view/PodWebView.java
+++ b/app/src/main/java/allen/town/podcast/view/PodWebView.java
@@ -64,7 +64,12 @@ public class PodWebView extends WebView implements View.OnLongClickListener {
             // Use cached resources, even if they have expired
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+            // COMPATIBILITY_MODE keeps passive sub-resources (cover art,
+            // images) loading on an https podcast show notes page while
+            // blocking active mixed content like remote scripts.
+            // ALWAYS_ALLOW is the strictly less safe option in the
+            // WebSettings javadoc.
+            getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
         }
         getSettings().setUseWideViewPort(false);
         getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NARROW_COLUMNS);


### PR DESCRIPTION
Closes #30.

`PodWebView.setup` called `setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW)` for the show-notes WebView. The `WebSettings` javadoc treats `ALWAYS_ALLOW` as the strictly less safe choice because it lets an https page load every kind of http sub-resource, including remote scripts.

### Change

Replace `MIXED_CONTENT_ALWAYS_ALLOW` with `MIXED_CONTENT_COMPATIBILITY_MODE`. `COMPATIBILITY_MODE` keeps passive sub-resources (cover art, podcast thumbnails over http) loading on https show-notes pages while blocking active mixed content like remote scripts. This matches how Chrome treats mixed content in the address bar and is the right default for podcast show notes.

One identifier swap, plus a short inline comment recording the trade-off.

Assisted-by: Claude (Anthropic)